### PR TITLE
Update test-dplyr-group-funs.R

### DIFF
--- a/tests/testthat/test-dplyr-group-funs.R
+++ b/tests/testthat/test-dplyr-group-funs.R
@@ -193,7 +193,7 @@ test_that("group_vars() returns virtual groups", {
   # I think it is correct to expect that tbl_vars()
   # doesn't return the virtual group
   expect_equal(
-    tbl_vars(x),
+    as.character(tbl_vars(x)),
     colnames(iris)
   )
 


### PR DESCRIPTION
Adapt test because what `tbl_vars()` returns has changed in dplyr 0.8.2

see https://github.com/tidyverse/dplyr/pull/4399